### PR TITLE
Add class ref sync action for blazium releases

### DIFF
--- a/.github/workflows/blazium_sync_class_ref.yml
+++ b/.github/workflows/blazium_sync_class_ref.yml
@@ -1,0 +1,69 @@
+name: Blazium Sync Class Reference
+
+on:
+  workflow_dispatch:
+
+# Make sure jobs cannot overlap.
+concurrency:
+  group: classref-sync-ci-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Update class reference files based on the lateste engine release tag
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout the documentation repository
+        uses: actions/checkout@v4
+
+      - name: Checkout the engine repository
+        uses: actions/checkout@v4
+        with:
+          repository: 'blazium-engine/blazium'
+          path: './.engine-src'
+          submodules: 'recursive'
+          fetch-depth: 0
+
+      - name: Store the engine revision at latest release
+        id: 'engine'
+        run: |
+          cd ./.engine-src
+          git fetch --tags
+          latest_tag=$(git tag -l "v*.*.*" | sed "s/v*.*.*-//g" | sort -V | tail -n 1)
+          echo "LATEST_TAG=$latest_tag" >> $GITHUB_ENV
+          git checkout $latest_tag
+          hash=$(git rev-parse HEAD)
+          hash_short=$(git rev-parse --short HEAD)
+          echo "Checked out blazium-engine/blazium at $hash"
+          echo "rev_hash=$hash" >> $GITHUB_OUTPUT
+          echo "rev_hash_short=$hash_short" >> $GITHUB_OUTPUT
+
+      - name: Remove old documentation
+        run: |
+          rm ./classes/class_*.rst
+
+      - name: Build new documentation
+        run: |
+          ./.engine-src/doc/tools/make_rst.py --color -o ./classes -l en ./.engine-src/doc/classes ./.engine-src/modules ./.engine-src/platform
+
+      - name: Submit a pull-request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: 'classref: Sync with current ${{ env.LATEST_TAG }} branch (${{ steps.engine.outputs.rev_hash_short }})'
+          branch: 'classref/sync-${{ steps.engine.outputs.rev_hash_short }}'
+          add-paths: './classes'
+          delete-branch: true
+
+          # Configure the commit author.
+          author: 'sshiiden <sshiiden@users.noreply.github.com>'
+          committer: 'sshiiden <sshiiden@users.noreply.github.com>'
+
+          # Configure the pull-request.
+          title: '[classref]: Sync with current ${{ env.LATEST_TAG }} release branch (${{ steps.engine.outputs.rev_hash_short }})'
+          body: 'Update Blazium API online class reference to match the engine at release https://github.com/blazium-engine/blazium/commit/${{ steps.engine.outputs.rev_hash }} (`${{ env.LATEST_TAG }}`).'
+          labels: 'class-ref-sync'


### PR DESCRIPTION
Closes #25
Action based of [`.github/workflows/sync_class_ref.yml`](https://github.com/blazium-engine/blazium-docs/blob/069e04a2ebf987bb28385b7f5543514c25ae7814/.github/workflows/sync_class_ref.yml)

It will create a pr with the changes from the latest release tag
