### PR TITLE
Fix references to master branch instead of blazium-dev

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,8 @@
 <!--
-Please target the `master` branch in priority.
-PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
+Please target the `blazium-dev` branch in priority.
+PRs can target other branches (e.g. `4.3`, `4.4`) if the same change was done in `blazium-dev`, or is not relevant there.
 PRs must not target `stable`, as that branch is updated manually.
 
 The type of content accepted into the documentation is explained here:
-https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
+https://docs.blazium.app/contributing/documentation/content_guidelines.html
 -->

--- a/_tools/redirects/create_redirects.py
+++ b/_tools/redirects/create_redirects.py
@@ -18,7 +18,7 @@ Example:
 
 This would add all files that were renamed in latest from stable to redirects.csv,
 and then create the redirects on RTD accordingly.
-Make sure to use the old branch first, then the more recent branch (i.e., stable > master).
+Make sure to use the old branch first, then the more recent branch (i.e., stable > blazium-dev).
 You need to have both branches or revisions available and up to date locally.
 Care is taken to not add redirects that already exist on RTD.
 """

--- a/about/complying_with_licenses.rst
+++ b/about/complying_with_licenses.rst
@@ -154,7 +154,7 @@ license text in the final product's documentation.
 
 Given the scope of the Blazium project, this is fairly difficult to do thoroughly.
 For the Blazium editor, the full documentation of third-party copyrights and
-licenses is provided in the `COPYRIGHT.txt <https://github.com/godotengine/godot/blob/master/COPYRIGHT.txt>`_
+licenses is provided in the `COPYRIGHT.txt <https://github.com/blazium-engine/blazium/blob/blazium-dev/COPYRIGHT.txt>`_
 file.
 
 A good option for end users to document third-party licenses is to include this

--- a/about/list_of_features.rst
+++ b/about/list_of_features.rst
@@ -749,7 +749,7 @@ Miscellaneous
 - :ref:`Command line interface <doc_command_line_tutorial>` for automation.
 
    - Export and deploy projects using continuous integration platforms.
-   - `Shell completion scripts <https://github.com/godotengine/godot/tree/master/misc/dist/shell>`__
+   - `Shell completion scripts <https://github.com/blazium-engine/blazium/tree/blazium-dev/misc/dist/shell>`__
      are available for Bash, zsh and fish.
    - Print colored text to standard output on all platforms using
      :ref:`print_rich <class_@GlobalScope_method_print_rich>`.

--- a/community/tutorials.rst
+++ b/community/tutorials.rst
@@ -8,7 +8,7 @@ community. For resources, remember that there is the official
 `Godot Asset Library <https://godotengine.org/asset-library/asset>`_ full of
 official and community resources too!
 
-Think there is something missing here? Feel free to submit a `Pull Request <https://github.com/blazium-engine/blazium-docs/blob/master/community/tutorials.rst>`_ as always.
+Think there is something missing here? Feel free to submit a `Pull Request <https://github.com/blazium-engine/blazium-docs/blob/blazium-dev/community/tutorials.rst>`_ as always.
 
 Where to start
 --------------

--- a/conf.py
+++ b/conf.py
@@ -183,7 +183,7 @@ html_context = {
     "display_github": not is_i18n,  # Integrate GitHub
     "github_user": "blazium-engine",  # Username
     "github_repo": "blazium-docs",  # Repo name
-    "github_version": "master",  # Version for Edit on GitHub - keep `master` for 4.x branches
+    "github_version": "blazium-dev",  # Version for Edit on GitHub - keep `blazium-dev` for 4.x branches
     "conf_py_path": "/",  # Path in the checkout to the docs root
     "godot_docs_title": supported_languages[language],
     "godot_docs_basepath": "https://docs.blazium.app/",

--- a/contributing/development/code_style_guidelines.rst
+++ b/contributing/development/code_style_guidelines.rst
@@ -26,7 +26,7 @@ To name a few:
 - See further down regarding header includes
 
 The rules used by clang-format are outlined in the
-`.clang-format <https://github.com/blazium-engine/blazium/blob/master/.clang-format>`__
+`.clang-format <https://github.com/blazium-engine/blazium/blob/blazium-dev/.clang-format>`__
 file of the Blazium repository.
 
 As long as you ensure that your style matches the surrounding code and that you're

--- a/contributing/development/compiling/compiling_for_linuxbsd.rst
+++ b/contributing/development/compiling/compiling_for_linuxbsd.rst
@@ -516,7 +516,7 @@ repositories, so you will have to install its binaries manually.
 Using system libraries for faster development
 ---------------------------------------------
 
-`Blazium bundles the source code of various third-party libraries. <https://github.com/blazium-engine/blazium/tree/master/thirdparty>`__
+`Blazium bundles the source code of various third-party libraries. <https://github.com/blazium-engine/blazium/tree/blazium-dev/thirdparty>`__
 You can choose to use system versions of third-party libraries instead.
 This makes the Blazium binary faster to link, as third-party libraries are
 dynamically linked. Therefore, they don't need to be statically linked
@@ -589,7 +589,7 @@ After installing all required packages, use the following command to build Blazi
     scons platform=linuxbsd builtin_embree=no builtin_enet=no builtin_freetype=no builtin_graphite=no builtin_harfbuzz=no builtin_libogg=no builtin_libpng=no builtin_libtheora=no builtin_libvorbis=no builtin_libwebp=no builtin_mbedtls=no builtin_miniupnpc=no builtin_pcre2=no builtin_zlib=no builtin_zstd=no
 
 On Debian stable, you will need to remove `builtin_embree=no` as the system-provided
-Embree version is too old to work with Blazium's latest `master` branch
+Embree version is too old to work with Blazium's latest `blazium-dev` branch
 (which requires Embree 4).
 
 You can view a list of all built-in libraries that have system alternatives by

--- a/contributing/development/compiling/compiling_for_macos.rst
+++ b/contributing/development/compiling/compiling_for_macos.rst
@@ -104,7 +104,7 @@ editor binary built with ``dev_build=yes``::
 
 .. note::
 
-    If you are building the ``master`` branch, you also need to include support
+    If you are building the ``blazium-dev`` branch, you also need to include support
     for the MoltenVK Vulkan portability library. By default, it will be linked
     statically from your installation of the Vulkan SDK for macOS.
     You can also choose to link it dynamically by passing ``use_volk=yes`` and

--- a/contributing/development/compiling/compiling_for_web.rst
+++ b/contributing/development/compiling/compiling_for_web.rst
@@ -108,7 +108,7 @@ server requirements.
 .. tip::
 
     The Blazium repository includes a
-    `Python script to host a local web server <https://raw.githubusercontent.com/godotengine/godot/master/platform/web/serve.py>`__.
+    `Python script to host a local web server <https://raw.githubusercontent.com/blazium-engine/blazium/blazium-dev/platform/web/serve.py>`__.
     This can be used to test the web editor locally.
 
     After compiling the editor, extract the ZIP archive that was created in the

--- a/contributing/development/compiling/compiling_for_windows.rst
+++ b/contributing/development/compiling/compiling_for_windows.rst
@@ -26,7 +26,7 @@ For compiling under Windows, the following is required:
       Supports ``x86_64``, ``x86_32``, and ``arm64``.
     - `MinGW-w64 <https://mingw-w64.org/>`_ with GCC can be used as an alternative to
       Visual Studio. Be sure to install/configure it to use the ``posix`` thread model.
-      **Important:** When using MinGW to compile the ``master`` branch, you need GCC 9 or later.
+      **Important:** When using MinGW to compile the ``blazium-dev`` branch, you need GCC 9 or later.
       Supports ``x86_64`` and ``x86_32`` only.
     - `MinGW-LLVM <https://github.com/mstorsjo/llvm-mingw/releases>`_ with clang can be used as
       an alternative to Visual Studio and MinGW-w64.

--- a/contributing/development/compiling/getting_source.rst
+++ b/contributing/development/compiling/getting_source.rst
@@ -24,7 +24,7 @@ If you don't know much about ``git`` yet, there are a great number of
 In general, you need to install ``git`` and/or one of the various GUI clients.
 
 Afterwards, to get the latest development version of the Blazium source code
-(the unstable ``master`` branch), you can use ``git clone``.
+(the unstable ``blazium-dev`` branch), you can use ``git clone``.
 
 If you are using the ``git`` command line client, this is done by entering
 the following in a terminal:

--- a/contributing/development/compiling/introduction_to_the_buildsystem.rst
+++ b/contributing/development/compiling/introduction_to_the_buildsystem.rst
@@ -470,7 +470,7 @@ directory to avoid conflicts. For instance, if you are building export templates
 for Godot 3.1.1, ``version.txt`` should contain ``3.1.1.stable`` on the first
 line (and nothing else). This version identifier is based on the ``major``,
 ``minor``, ``patch`` (if present) and ``status`` lines of the
-`version.py file in the Blazium Git repository <https://github.com/blazium-engine/blazium/blob/master/version.py>`__.
+`version.py file in the Blazium Git repository <https://github.com/blazium-engine/blazium/blob/blazium-dev/version.py>`__.
 
 If you are developing for multiple platforms, macOS is definitely the most
 convenient host platform for cross-compilation, since you can cross-compile for

--- a/contributing/development/compiling/optimizing_for_size.rst
+++ b/contributing/development/compiling/optimizing_for_size.rst
@@ -68,7 +68,7 @@ and MSVC compilers:
 Linking becomes much slower and more RAM-consuming with this option,
 so it should be used only for release builds:
 
-- When compiling the ``master`` branch, you need to have at least 8 GB of RAM
+- When compiling the ``blazium-dev`` branch, you need to have at least 8 GB of RAM
   available for successful linking with LTO enabled.
 - When compiling the ``3.x`` branch, you need to have at least 6 GB of RAM
   available for successful linking with LTO enabled.

--- a/contributing/development/core_and_modules/common_engine_methods_and_macros.rst
+++ b/contributing/development/core_and_modules/common_engine_methods_and_macros.rst
@@ -251,10 +251,10 @@ Blazium features many error macros to make error reporting more convenient.
 
 .. seealso::
 
-    See `core/error/error_macros.h <https://github.com/blazium-engine/blazium/blob/master/core/error/error_macros.h>`__
+    See `core/error/error_macros.h <https://github.com/blazium-engine/blazium/blob/blazium-dev/core/error/error_macros.h>`__
     in Blazium's codebase for more information about each error macro.
 
     Some functions return an error code (materialized by a return type of
     ``Error``). This value can be returned directly from an error macro.
     See the list of available error codes in
-    `core/error/error_list.h <https://github.com/blazium-engine/blazium/blob/master/core/error/error_list.h>`__.
+    `core/error/error_list.h <https://github.com/blazium-engine/blazium/blob/blazium-dev/core/error/error_list.h>`__.

--- a/contributing/development/core_and_modules/core_types.rst
+++ b/contributing/development/core_and_modules/core_types.rst
@@ -34,7 +34,7 @@ directly to wchar_t.
 References:
 ~~~~~~~~~~~
 
--  `core/typedefs.h <https://github.com/blazium-engine/blazium/blob/master/core/typedefs.h>`__
+-  `core/typedefs.h <https://github.com/blazium-engine/blazium/blob/blazium-dev/core/typedefs.h>`__
 
 Memory model
 ------------
@@ -131,7 +131,7 @@ fragmentation tend to be more important with small collections.
 References:
 ~~~~~~~~~~~
 
--  `core/os/memory.h <https://github.com/godotengine/godot/blob/master/core/os/memory.h>`__
+-  `core/os/memory.h <https://github.com/blazium-engine/blazium/blob/blazium-dev/core/os/memory.h>`__
 
 Containers
 ----------
@@ -164,10 +164,10 @@ The Vector<> class also has a few nice features:
 References:
 ~~~~~~~~~~~
 
--  `core/templates/vector.h <https://github.com/blazium-engine/blazium/blob/master/core/templates/vector.h>`__
--  `core/templates/list.h <https://github.com/blazium-engine/blazium/blob/master/core/templates/list.h>`__
--  `core/templates/set.h <https://github.com/blazium-engine/blazium/blob/master/core/templates/hash_set.h>`__
--  `core/templates/map.h <https://github.com/blazium-engine/blazium/blob/master/core/templates/hash_map.h>`__
+-  `core/templates/vector.h <https://github.com/blazium-engine/blazium/blob/blazium-dev/core/templates/vector.h>`__
+-  `core/templates/list.h <https://github.com/blazium-engine/blazium/blob/blazium-dev/core/templates/list.h>`__
+-  `core/templates/set.h <https://github.com/blazium-engine/blazium/blob/blazium-dev/core/templates/hash_set.h>`__
+-  `core/templates/map.h <https://github.com/blazium-engine/blazium/blob/blazium-dev/core/templates/hash_map.h>`__
 
 String
 ------
@@ -180,7 +180,7 @@ conversion and visualization.
 References:
 ~~~~~~~~~~~
 
--  `core/string/ustring.h <https://github.com/blazium-engine/blazium/blob/master/core/string/ustring.h>`__
+-  `core/string/ustring.h <https://github.com/blazium-engine/blazium/blob/blazium-dev/core/string/ustring.h>`__
 
 StringName
 ----------
@@ -196,7 +196,7 @@ is fast.
 References:
 ~~~~~~~~~~~
 
--  `core/string/string_name.h <https://github.com/blazium-engine/blazium/blob/master/core/string/string_name.h>`__
+-  `core/string/string_name.h <https://github.com/blazium-engine/blazium/blob/blazium-dev/core/string/string_name.h>`__
 
 Math types
 ----------
@@ -207,7 +207,7 @@ directory.
 References:
 ~~~~~~~~~~~
 
--  `core/math <https://github.com/blazium-engine/blazium/tree/master/core/math>`__
+-  `core/math <https://github.com/blazium-engine/blazium/tree/blazium-dev/core/math>`__
 
 NodePath
 --------
@@ -218,7 +218,7 @@ referencing them fast.
 References:
 ~~~~~~~~~~~
 
--  `core/string/node_path.h <https://github.com/blazium-engine/blazium/blob/master/core/string/node_path.h>`__
+-  `core/string/node_path.h <https://github.com/blazium-engine/blazium/blob/blazium-dev/core/string/node_path.h>`__
 
 RID
 ---
@@ -231,4 +231,4 @@ referenced data.
 References:
 ~~~~~~~~~~~
 
--  `core/templates/rid.h <https://github.com/blazium-engine/blazium/blob/master/core/templates/rid.h>`__
+-  `core/templates/rid.h <https://github.com/blazium-engine/blazium/blob/blazium-dev/core/templates/rid.h>`__

--- a/contributing/development/core_and_modules/custom_audiostreams.rst
+++ b/contributing/development/core_and_modules/custom_audiostreams.rst
@@ -22,8 +22,8 @@ This guide assumes the reader knows how to create C++ modules. If not, refer to 
 References:
 ~~~~~~~~~~~
 
--  `servers/audio/audio_stream.h <https://github.com/blazium-engine/blazium/blob/master/servers/audio/audio_stream.h>`__
--  `scene/audio/audio_stream_player.cpp <https://github.com/blazium-engine/blazium/blob/master/scene/audio/audio_stream_player.cpp>`__
+-  `servers/audio/audio_stream.h <https://github.com/blazium-engine/blazium/blob/blazium-dev/servers/audio/audio_stream.h>`__
+-  `scene/audio/audio_stream_player.cpp <https://github.com/blazium-engine/blazium/blob/blazium-dev/scene/audio/audio_stream_player.cpp>`__
 
 What for?
 ---------
@@ -114,7 +114,7 @@ Therefore, playback state must be self-contained in AudioStreamPlayback.
 References:
 ~~~~~~~~~~~
 
--  `servers/audio/audio_stream.h <https://github.com/blazium-engine/blazium/blob/master/servers/audio/audio_stream.h>`__
+-  `servers/audio/audio_stream.h <https://github.com/blazium-engine/blazium/blob/blazium-dev/servers/audio/audio_stream.h>`__
 
 
 Create an AudioStreamPlayback
@@ -344,6 +344,6 @@ query AudioFrames and ``get_stream_sampling_rate`` to query current mix rate.
 
 References:
 ~~~~~~~~~~~
--  `core/math/audio_frame.h <https://github.com/blazium-engine/blazium/blob/master/core/math/audio_frame.h>`__
--  `servers/audio/audio_stream.h <https://github.com/blazium-engine/blazium/blob/master/servers/audio/audio_stream.h>`__
--  `scene/audio/audio_stream_player.cpp <https://github.com/blazium-engine/blazium/blob/master/scene/audio/audio_stream_player.cpp>`__
+-  `core/math/audio_frame.h <https://github.com/blazium-engine/blazium/blob/blazium-dev/core/math/audio_frame.h>`__
+-  `servers/audio/audio_stream.h <https://github.com/blazium-engine/blazium/blob/blazium-dev/servers/audio/audio_stream.h>`__
+-  `scene/audio/audio_stream_player.cpp <https://github.com/blazium-engine/blazium/blob/blazium-dev/scene/audio/audio_stream_player.cpp>`__

--- a/contributing/development/core_and_modules/custom_godot_servers.rst
+++ b/contributing/development/core_and_modules/custom_godot_servers.rst
@@ -77,7 +77,7 @@ an initialization state and a cleanup procedure.
     private:
         uint64_t counter;
         RID_Owner<InfiniteBus> bus_owner;
-        // https://github.com/godotengine/godot/blob/master/core/templates/rid.h
+        // https://github.com/blazium-engine/blazium/blob/blazium-dev/core/templates/rid.h
         Set<RID> buses;
         void _emit_occupy_room(uint64_t room, RID rid);
 
@@ -204,7 +204,7 @@ an initialization state and a cleanup procedure.
         return ret;
     }
 
-    // https://github.com/godotengine/godot/blob/master/core/templates/rid.h
+    // https://github.com/blazium-engine/blazium/blob/blazium-dev/core/templates/rid.h
     bool HilbertHotel::delete_bus(RID id) {
         if (bus_owner.owns(id)) {
             lock();
@@ -314,7 +314,7 @@ References
 ~~~~~~~~~~~
 
 - :ref:`RID<class_rid>`
-- `core/templates/rid.h <https://github.com/blazium-engine/blazium/blob/master/core/templates/rid.h>`__
+- `core/templates/rid.h <https://github.com/blazium-engine/blazium/blob/blazium-dev/core/templates/rid.h>`__
 
 Registering the class in GDScript
 ---------------------------------
@@ -369,7 +369,7 @@ is used to register the dummy class in GDScript.
         }
     }
 
-- `servers/register_server_types.cpp <https://github.com/blazium-engine/blazium/blob/master/servers/register_server_types.cpp>`__
+- `servers/register_server_types.cpp <https://github.com/blazium-engine/blazium/blob/blazium-dev/servers/register_server_types.cpp>`__
 
 Bind methods
 ~~~~~~~~~~~~
@@ -470,7 +470,7 @@ to execute the desired behavior. The queue will be flushed whenever either
 References:
 ~~~~~~~~~~~
 
-- `core/object/message_queue.cpp <https://github.com/blazium-engine/blazium/blob/master/core/object/message_queue.cpp>`__
+- `core/object/message_queue.cpp <https://github.com/blazium-engine/blazium/blob/blazium-dev/core/object/message_queue.cpp>`__
 
 Summing it up
 -------------

--- a/contributing/development/core_and_modules/custom_platform_ports.rst
+++ b/contributing/development/core_and_modules/custom_platform_ports.rst
@@ -41,17 +41,17 @@ Official platform ports
 
 The official platform ports can be used as a reference when creating a custom platform port:
 
-- `Windows <https://github.com/blazium-engine/blazium/tree/master/platform/windows>`__
-- `macOS <https://github.com/blazium-engine/blazium/tree/master/platform/macos>`__
-- `Linux/\*BSD <https://github.com/blazium-engine/blazium/tree/master/platform/linuxbsd>`__
-- `Android <https://github.com/blazium-engine/blazium/tree/master/platform/android>`__
-- `iOS <https://github.com/blazium-engine/blazium/tree/master/platform/ios>`__
-- `Web <https://github.com/blazium-engine/blazium/tree/master/platform/web>`__
+- `Windows <https://github.com/blazium-engine/blazium/tree/blazium-dev/platform/windows>`__
+- `macOS <https://github.com/blazium-engine/blazium/tree/blazium-dev/platform/macos>`__
+- `Linux/\*BSD <https://github.com/blazium-engine/blazium/tree/blazium-dev/platform/linuxbsd>`__
+- `Android <https://github.com/blazium-engine/blazium/tree/blazium-dev/platform/android>`__
+- `iOS <https://github.com/blazium-engine/blazium/tree/blazium-dev/platform/ios>`__
+- `Web <https://github.com/blazium-engine/blazium/tree/blazium-dev/platform/web>`__
 
 While platform code is usually self-contained, there are exceptions to this
 rule. For instance, audio drivers that are shared across several platforms and
 rendering drivers are located in the
-`drivers/ folder <https://github.com/blazium-engine/blazium/tree/master/drivers>`__
+`drivers/ folder <https://github.com/blazium-engine/blazium/tree/blazium-dev/drivers>`__
 of the Blazium source code.
 
 Creating a custom platform port
@@ -70,9 +70,9 @@ A ``logo.svg`` (32×32) vector image must also be present within the platform
 folder. This logo is displayed in the Export dialog for each export preset
 targeting the platform in question.
 
-See `this implementation <https://github.com/blazium-engine/blazium/blob/master/platform/linuxbsd/os_linuxbsd.cpp>`__
+See `this implementation <https://github.com/blazium-engine/blazium/blob/blazium-dev/platform/linuxbsd/os_linuxbsd.cpp>`__
 for the Linux/\*BSD platform as an example. See also the
-`OS singleton header <https://github.com/blazium-engine/blazium/blob/master/core/os/os.h>`__
+`OS singleton header <https://github.com/blazium-engine/blazium/blob/blazium-dev/core/os/os.h>`__
 for reference.
 
 .. note::
@@ -81,7 +81,7 @@ for reference.
     class to get much of the work done automatically.
 
     If the platform is not UNIX-like, you might use the
-    `Windows port <https://github.com/blazium-engine/blazium/blob/master/platform/windows/os_windows.cpp>`__
+    `Windows port <https://github.com/blazium-engine/blazium/blob/blazium-dev/platform/windows/os_windows.cpp>`
     as a reference.
 
 **detect.py file**
@@ -89,7 +89,7 @@ for reference.
 A ``detect.py`` file must be created within the platform's folder with all
 methods implemented. This file is required for SCons to detect the platform as a
 valid option for compiling. See the
-`detect.py file <https://github.com/blazium-engine/blazium/blob/master/platform/linuxbsd/detect.py>`__
+`detect.py file <https://github.com/blazium-engine/blazium/blob/blazium-dev/platform/linuxbsd/detect.py>`__
 for the Linux/\*BSD platform as an example.
 
 All methods should be implemented within ``detect.py`` as follows:
@@ -116,11 +116,11 @@ games.
 
 *Some links on this list point to the Linux/\*BSD platform implementation as a reference.*
 
-- One or more `DisplayServers <https://github.com/blazium-engine/blazium/blob/master/platform/linuxbsd/x11/display_server_x11.cpp>`__,
+- One or more `DisplayServers <https://github.com/blazium-engine/blazium/blob/blazium-dev/platform/linuxbsd/x11/display_server_x11.cpp>`__,
   with the windowing methods implemented. DisplayServer also covers features such
   as mouse support, touchscreen support and tablet driver (for pen input).
   See the
-  `DisplayServer singleton header <https://github.com/blazium-engine/blazium/blob/master/servers/display_server.h>`__
+  `DisplayServer singleton header <https://github.com/blazium-engine/blazium/blob/blazium-dev/servers/display_server.h>`__
   for reference.
 
   - For platforms not featuring full windowing support (or if it's not relevant
@@ -130,27 +130,27 @@ games.
     platform's screen resolution feature (if relevant). Any attempt to create
     or manipulate other window IDs can be rejected.
 - *If the target platform supports the graphics APIs in question:* Rendering
-  context for `Vulkan <https://github.com/blazium-engine/blazium/blob/master/platform/linuxbsd/x11/rendering_context_driver_vulkan_x11.cpp>`__,
-  `Direct3D 12 <https://github.com/godotengine/godot/blob/master/drivers/d3d12/rendering_context_driver_d3d12.cpp>`__
-  `OpenGL 3.3 or OpenGL ES 3.0 <https://github.com/blazium-engine/blazium/blob/master/platform/linuxbsd/x11/gl_manager_x11.cpp>`__.
-- Input handlers for `keyboard <https://github.com/blazium-engine/blazium/blob/master/platform/linuxbsd/x11/key_mapping_x11.cpp>`__
-  and `controller <https://github.com/blazium-engine/blazium/blob/master/platform/linuxbsd/joypad_linux.cpp>`__.
-- One or more `audio drivers <https://github.com/blazium-engine/blazium/blob/master/drivers/pulseaudio/audio_driver_pulseaudio.cpp>`__.
+  context for `Vulkan <https://github.com/blazium-engine/blazium/blob/blazium-dev/platform/linuxbsd/x11/rendering_context_driver_vulkan_x11.cpp>`__,
+  `Direct3D 12 <https://github.com/godotengine/godot/blob/blazium-dev/drivers/d3d12/rendering_context_driver_d3d12.cpp>`__
+  `OpenGL 3.3 or OpenGL ES 3.0 <https://github.com/blazium-engine/blazium/blob/blazium-dev/platform/linuxbsd/x11/gl_manager_x11.cpp>`__.
+- Input handlers for `keyboard <https://github.com/blazium-engine/blazium/blob/blazium-dev/platform/linuxbsd/x11/key_mapping_x11.cpp>`__
+  and `controller <https://github.com/blazium-engine/blazium/blob/blazium-dev/platform/linuxbsd/joypad_linux.cpp>`__.
+- One or more `audio drivers <https://github.com/blazium-engine/blazium/blob/blazium-dev/drivers/pulseaudio/audio_driver_pulseaudio.cpp>`__.
   The audio driver can be located in the ``platform/`` folder (this is done for
   the Android and Web platforms), or in the ``drivers/`` folder if multiple
   platforms may be using this audio driver. See the
-  `AudioServer singleton header <https://github.com/blazium-engine/blazium/blob/master/servers/audio_server.h>`__
+  `AudioServer singleton header <https://github.com/blazium-engine/blazium/blob/blazium-dev/servers/audio_server.h>`__
   for reference.
-- `Crash handler <https://github.com/blazium-engine/blazium/blob/master/platform/linuxbsd/crash_handler_linuxbsd.cpp>`__,
+- `Crash handler <https://github.com/blazium-engine/blazium/blob/blazium-dev/platform/linuxbsd/crash_handler_linuxbsd.cpp>`__,
   for printing crash backtraces when the game crashes. This allows for easier
   troubleshooting on platforms where logs aren't readily accessible.
-- `Text-to-speech driver <https://github.com/blazium-engine/blazium/blob/master/platform/linuxbsd/tts_linux.cpp>`__
+- `Text-to-speech driver <https://github.com/blazium-engine/blazium/blob/blazium-dev/platform/linuxbsd/tts_linux.cpp>`__
   (for accessibility).
-- `Export handler <https://github.com/blazium-engine/blazium/tree/master/platform/linuxbsd/export>`__
+- `Export handler <https://github.com/blazium-engine/blazium/tree/blazium-dev/platform/linuxbsd/export>`__
   (for exporting from the editor, including :ref:`doc_one-click_deploy`).
   Not required if you intend to export only a PCK from the editor, then run the
   export template binary directly by renaming it to match the PCK file. See the
-  `EditorExportPlatform header <https://github.com/blazium-engine/blazium/blob/master/editor/export/editor_export_platform.h>`__
+  `EditorExportPlatform header <https://github.com/blazium-engine/blazium/blob/blazium-dev/editor/export/editor_export_platform.h>`__
   for reference.
   ``run_icon.svg`` (16×16) should be present within the platform folder if
   :ref:`doc_one-click_deploy` is implemented for the target platform. This icon

--- a/contributing/development/core_and_modules/custom_resource_format_loaders.rst
+++ b/contributing/development/core_and_modules/custom_resource_format_loaders.rst
@@ -18,7 +18,7 @@ References
 ~~~~~~~~~~
 
 - :ref:`ResourceLoader<class_resourceloader>`
-- `core/io/resource_loader.cpp <https://github.com/blazium-engine/blazium/blob/master/core/io/resource_loader.cpp>`_
+- `core/io/resource_loader.cpp <https://github.com/blazium-engine/blazium/blob/blazium-dev/core/io/resource_loader.cpp>`_
 
 What for?
 ---------
@@ -38,7 +38,7 @@ ImageFormatLoader should be used to load images.
 References
 ~~~~~~~~~~
 
-- `core/io/image_loader.h <https://github.com/blazium-engine/blazium/blob/master/core/io/image_loader.h>`_
+- `core/io/image_loader.h <https://github.com/blazium-engine/blazium/blob/blazium-dev/core/io/image_loader.h>`_
 
 
 Creating a ResourceFormatLoader
@@ -298,7 +298,7 @@ References
 
 - `istream <https://cplusplus.com/reference/istream/istream/>`_
 - `streambuf <https://cplusplus.com/reference/streambuf/streambuf/?kw=streambuf>`_
-- `core/io/file_access.h <https://github.com/blazium-engine/blazium/blob/master/core/io/file_access.h>`_
+- `core/io/file_access.h <https://github.com/blazium-engine/blazium/blob/blazium-dev/core/io/file_access.h>`_
 
 Registering the new file format
 -------------------------------
@@ -347,7 +347,7 @@ when ``load`` is called.
 References
 ~~~~~~~~~~
 
-- `core/io/resource_loader.cpp <https://github.com/blazium-engine/blazium/blob/master/core/io/resource_loader.cpp>`_
+- `core/io/resource_loader.cpp <https://github.com/blazium-engine/blazium/blob/blazium-dev/core/io/resource_loader.cpp>`_
 
 Loading it on GDScript
 ----------------------

--- a/contributing/development/core_and_modules/internal_rendering_architecture.rst
+++ b/contributing/development/core_and_modules/internal_rendering_architecture.rst
@@ -291,7 +291,7 @@ RenderingDevice presents a similar level of abstraction as WebGPU.
 
 **Metal RenderingDevice implementation:**
 
-- `drivers/metal/rendering_device_driver_metal.mm <https://github.com/godotengine/godot/blob/master/drivers/metal/rendering_device_driver_metal.mm>`__
+- `drivers/metal/rendering_device_driver_metal.mm <https://github.com/blazium-engine/blazium/blob/blazium-dev/drivers/metal/rendering_device_driver_metal.mm>`__
 
 Core rendering classes architecture
 -----------------------------------

--- a/contributing/development/core_and_modules/object_class.rst
+++ b/contributing/development/core_and_modules/object_class.rst
@@ -35,7 +35,7 @@ This adds a lot of functionality to Objects. For example:
 References:
 ~~~~~~~~~~~
 
--  `core/object/object.h <https://github.com/blazium-engine/blazium/blob/master/core/object/object.h>`__
+-  `core/object/object.h <https://github.com/blazium-engine/blazium/blob/blazium-dev/core/object/object.h>`__
 
 Registering an Object
 ---------------------
@@ -97,7 +97,7 @@ string passing the name can be passed for brevity.
 References:
 ~~~~~~~~~~~
 
--  `core/object/class_db.h <https://github.com/blazium-engine/blazium/blob/master/core/object/class_db.h>`__
+-  `core/object/class_db.h <https://github.com/blazium-engine/blazium/blob/blazium-dev/core/object/class_db.h>`__
 
 Constants
 ---------
@@ -269,7 +269,7 @@ templates point to it.
 References:
 ~~~~~~~~~~~
 
--  `core/object/reference.h <https://github.com/blazium-engine/blazium/blob/master/core/object/ref_counted.h>`__
+-  `core/object/reference.h <https://github.com/blazium-engine/blazium/blob/blazium-dev/core/object/ref_counted.h>`__
 
 Resources
 ----------
@@ -285,7 +285,7 @@ Resources without a path are fine too.
 References:
 ~~~~~~~~~~~
 
--  `core/io/resource.h <https://github.com/blazium-engine/blazium/blob/master/core/io/resource.h>`__
+-  `core/io/resource.h <https://github.com/blazium-engine/blazium/blob/blazium-dev/core/io/resource.h>`__
 
 Resource loading
 ----------------
@@ -306,7 +306,7 @@ the same time.
 References:
 ~~~~~~~~~~~
 
--  `core/io/resource_loader.h <https://github.com/blazium-engine/blazium/blob/master/core/io/resource_loader.h>`__
+-  `core/io/resource_loader.h <https://github.com/blazium-engine/blazium/blob/blazium-dev/core/io/resource_loader.h>`__
 
 Resource saving
 ---------------
@@ -325,4 +325,4 @@ be bundled with the saved resource and assigned sub-IDs, like
 References:
 ~~~~~~~~~~~
 
--  `core/io/resource_saver.h <https://github.com/blazium-engine/blazium/blob/master/core/io/resource_saver.h>`__
+-  `core/io/resource_saver.h <https://github.com/blazium-engine/blazium/blob/blazium-dev/core/io/resource_saver.h>`__

--- a/contributing/development/core_and_modules/unit_testing.rst
+++ b/contributing/development/core_and_modules/unit_testing.rst
@@ -142,7 +142,7 @@ writing test cases themselves.
 
 .. seealso::
 
-    `tests/test_macros.h <https://github.com/blazium-engine/blazium/blob/master/tests/test_macros.h>`_
+    `tests/test_macros.h <https://github.com/blazium-engine/blazium/blob/blazium-dev/tests/test_macros.h>`_
     source code for currently implemented macros and aliases for them.
 
 Test cases are created using ``TEST_CASE`` function-like macro. Each test case

--- a/contributing/development/core_and_modules/variant_class.rst
+++ b/contributing/development/core_and_modules/variant_class.rst
@@ -46,7 +46,7 @@ of C++ with little effort. Become a friend of Variant today.
 References
 ~~~~~~~~~~
 
--  `core/variant/variant.h <https://github.com/blazium-engine/blaziumg/blob/master/core/variant/variant.h>`__
+-  `core/variant/variant.h <https://github.com/blazium-engine/blaziumg/blob/blazium-dev/core/variant/variant.h>`__
 
 List of variant types
 ---------------------
@@ -150,5 +150,5 @@ it. A Mutex should be created to lock it if
 References
 ~~~~~~~~~~
 
--  `core/variant/dictionary.h <https://github.com/blazium-engine/blazium/blob/master/core/variant/dictionary.h>`__
--  `core/variant/array.h <https://github.com/blazium-engine/blazium/blob/master/core/variant/array.h>`__
+-  `core/variant/dictionary.h <https://github.com/blazium-engine/blazium/blob/blazium-dev/core/variant/dictionary.h>`__
+-  `core/variant/array.h <https://github.com/blazium-engine/blazium/blob/blazium-dev/core/variant/array.h>`__

--- a/contributing/documentation/building_the_manual.rst
+++ b/contributing/documentation/building_the_manual.rst
@@ -183,12 +183,12 @@ the last commit (``sed`` is used to put them on the same line).
 
     make html FILELIST="$(git diff HEAD --name-only | sed -z 's/\n/ /g')"
 
-You can replace ``HEAD`` with ``master`` to return all files changed from the
-``master`` branch:
+You can replace ``HEAD`` with ``blazium-dev`` to return all files changed from the
+``blazium-dev`` branch:
 
 .. code:: sh
 
-    make html FILELIST="$(git diff master --name-only | sed -z 's/\n/ /g')"
+    make html FILELIST="$(git diff blazium-dev --name-only | sed -z 's/\n/ /g')"
 
 If any images were modified, the output will contain some warnings about them,
 but the build will proceed correctly.

--- a/contributing/documentation/contributing_to_the_documentation.rst
+++ b/contributing/documentation/contributing_to_the_documentation.rst
@@ -49,10 +49,10 @@ contribute, you should also read:
 Contributing changes
 --------------------
 
-**Pull requests should use the** ``master`` **branch by default.** Only make pull
+**Pull requests should use the** ``blazium-dev`` **branch by default.** Only make pull
 requests against other branches (e.g. ``3.6`` or ``4.2``) if your changes only
 apply to that specific version of Blazium. After a pull request is merged into
-``master``, it will usually be cherry-picked into the current stable branch by
+``blazium-dev``, it will usually be cherry-picked into the current stable branch by
 documentation maintainers.
 
 Though less convenient to edit than a wiki, this Git repository is where we
@@ -66,7 +66,7 @@ To edit an existing page, locate its ``.rst`` source file and open it in your
 favorite text editor. You can then commit the changes, push them to your fork,
 and make a pull request. **Note that the pages in** ``classes/`` **should not be
 edited here.** They are automatically generated from Blazium's `XML class
-reference <https://github.com/blazium-engine/blazium/tree/master/doc/classes>`__.
+reference <https://github.com/blazium-engine/blazium/tree/blazium-dev/doc/classes>`__.
 See :ref:`doc_updating_the_class_reference` for details.
 
 .. seealso:: To build the manual and test changes on your computer, see
@@ -83,7 +83,7 @@ and to log in to use it. Once logged in, you can propose change like so:
 
 1. Click the **Edit on GitHub** button.
 
-2. On the GitHub page you're taken to, make sure the current branch is "master".
+2. On the GitHub page you're taken to, make sure the current branch is "blazium-dev".
    Click the pencil icon in the top-right corner
    near the **Raw**, **Blame**, and **Delete** buttons.
    It has the tooltip "Fork this project and edit the file".
@@ -96,15 +96,15 @@ and to log in to use it. Once logged in, you can propose change like so:
    Click the button **Propose changes**.
 
 5. On the following screens, click the **Create pull request** button until you
-   see a message like *Username wants to merge 1 commit into blazium-engine:master
+   see a message like *Username wants to merge 1 commit into blazium-engine:blazium-dev
    from Username:patch-1*.
 
 .. note::
 
    If there are more commits than your own in the pull request
    it is likely that your branch was created using the wrong origin,
-   due to "master" not being the current branch in step 2.
-   You will need to rebase your branch to "master" or create a new branch.
+   due to "blazium-dev" not being the current branch in step 2.
+   You will need to rebase your branch to "blazium-dev" or create a new branch.
 
 Another contributor will review your changes and merge them into the docs if
 they're good. They may also make changes or ask you to do so before merging.

--- a/contributing/documentation/editor_and_docs_localization.rst
+++ b/contributing/documentation/editor_and_docs_localization.rst
@@ -263,11 +263,11 @@ external links, etc. Here are some examples::
     `Have a look here <https://docs.blazium.app>`_.
 
     # "|supported|" is an inline reference to an image and should stay unchanged.
-    # "master" uses the markup for inline code, and will be styled as such.
+    # "blazium-dev" uses the markup for inline code, and will be styled as such.
     # Note: Inline code in RST uses 2 backticks on each side, unlike Markdown.
     # Single backticks are used for hyperlinks.
 
-    |supported| Backwards-compatible new features (backported from the ``master``
+    |supported| Backwards-compatible new features (backported from the ``blazium-dev``
     branch) as well as bug, security, and platform support fixes.
 
     # The :ref: Sphinx "role" is used for internal references to other pages of
@@ -359,11 +359,11 @@ can use the downloaded PO file and :ref:`compile Blazium from source <toc-devel-
 
 Rename the editor translation PO file to ``<lang>.po`` (e.g. ``eo.po`` for
 Esperanto) and place it in the ``editor/translations/`` folder
-(`GitHub <https://github.com/blazium-engine/blazium/tree/master/editor/translations>`__).
+(`GitHub <https://github.com/blazium-engine/blazium/tree/blazium-dev/editor/translations>`__).
 
 You can also test class reference changes the same way by renaming the PO file
 similarly and placing it in the ``doc/translations/`` folder
-(`GitHub <https://github.com/blazium-engine/blazium/tree/master/doc/translations>`__).
+(`GitHub <https://github.com/blazium-engine/blazium/tree/blazium-dev/doc/translations>`__).
 
 Localizing documentation images
 -------------------------------

--- a/contributing/documentation/updating_the_class_reference.rst
+++ b/contributing/documentation/updating_the_class_reference.rst
@@ -34,7 +34,7 @@ is picked as the source of truth, and the documentation for the class reference 
 
 In the main repository the class reference is stored in XML files, one for each exposed
 class or global object. The majority of these files is located in `doc/classes/
-<https://github.com/blazium-engine/blazium/tree/master/doc/classes>`_, but some modules
+<https://github.com/blazium-engine/blazium/tree/blazium-dev/doc/classes>`_, but some modules
 contain their own documentation as well. You will find it in the ``modules/<module_name>/doc_classes/``
 directory. To learn more about editing XML files refer to :ref:`doc_class_reference_primer`.
 

--- a/contributing/how_to_contribute.rst
+++ b/contributing/how_to_contribute.rst
@@ -37,7 +37,7 @@ Technical contributions
   .. `List of teams <https://godotengine.org/teams/>`_
 
 - **Review Code Contributions**
-  All pull requests need to be thoroughly reviewed before they can be merged into the master branch.
+  All pull requests need to be thoroughly reviewed before they can be merged into the blazium-dev branch.
   Help us get a headstart by participating in the code review process.
 
   To get started, chose any `open pull request <https://github.com/blazium-engine/blazium/pulls>`_ and reference our **style guide**: :ref:`doc_pr_review_guidelines`

--- a/contributing/workflow/bisecting_regressions.rst
+++ b/contributing/workflow/bisecting_regressions.rst
@@ -74,7 +74,7 @@ the "bad" and "good" build. "bad" refers to the build that exhibits the bug,
 whereas "good" refers to the version that doesn't exhibit the bug. 
 
 You can use either a commit hash (like ``06acfccf8``), the tag of a stable
-release (like ``4.2.1-stable``), or a branch like ``master``.
+release (like ``4.2.1-stable``), or a branch like ``blazium-dev``.
 
 If you're using a pre-release build as the "good" or "bad" build, you can find
 the commit hash in the Project Manager in the lower-right corner, or in in the
@@ -97,9 +97,9 @@ list of release tags is available `on GitHub
 <https://github.com/godotengine/godot/tags>`__, and you can also find the actual
 commit hash that corresponds to a stable release there.
 
-To refer to the latest state of the master branch, you can use ``master``
+To refer to the latest state of the blazium-dev branch, you can use ``blazium-dev``
 instead of a commit hash. Note that unlike tagged releases or snapshot commit
-hashes, ``master`` is a perpetually moving target.
+hashes, ``blazium-dev`` is a perpetually moving target.
 
 Build the engine
 ~~~~~~~~~~~~~~~~

--- a/contributing/workflow/bug_triage_guidelines.rst
+++ b/contributing/workflow/bug_triage_guidelines.rst
@@ -45,7 +45,7 @@ currently defined in the Blazium repository:
    compatibility with existing projects.
 -  *Bug*: describes something that is not working properly.
 -  *Cherrypick*: describes something that can be backported to a stable branch
-   after being merged in the ``master`` branch.
+   after being merged in the ``blazium-dev`` branch.
 -  *Confirmed*: has been confirmed by at least one other contributor
    than the bug reporter (typically for *Bug* reports).
    The purpose of this label is to let developers know which issues are
@@ -166,7 +166,7 @@ use the following `labels <https://github.com/blazium-engine/blaizum-docs/labels
 -  *Bug*: Incorrect information in an existing page. Not to be used for
    *missing* information.
 -  *Cherrypick*: describes something that can be backported to a stable branch
-   after being merged in the ``master`` branch.
+   after being merged in the ``blazium-dev`` branch.
 -  *Dependencies*: describes pull requests that update a dependency file.
 -  *Discussion*: the issue is not consensual and needs further
    discussion to define what exactly should be done to address the

--- a/contributing/workflow/pr_review_guidelines.rst
+++ b/contributing/workflow/pr_review_guidelines.rst
@@ -327,7 +327,7 @@ out more broadly to ask for help reviewing. Consider asking:
 * **Make sure that the PR has no merge conflicts.**
 
   Contributors may need to rebase their changes on top of the relevant branch
-  (e.g. ``master`` or ``3.x``) and manually fix merge conflicts. Even if there
+  (e.g. ``blazium-dev`` or ``3.x``) and manually fix merge conflicts. Even if there
   are no merge conflicts, contributors may need to rebase especially old PRs as
   the GitHub conflict checker may not catch all conflicts, or the CI may have
   changed since it was originally run.
@@ -352,7 +352,7 @@ out more broadly to ask for help reviewing. Consider asking:
   maintainer you've probably written them enough times to know how to make one,
   but for a general template think about *"Fix <issue> in <part of codebase>"*.
   For a more detailed recommendation see the `contributing.md
-  <https://github.com/blazium-engine/blazium/blob/master/CONTRIBUTING.md#format-your-commit-messages-with-readability-in-mind>`_
+  <https://github.com/blazium-engine/blazium/blob/blazium-dev/CONTRIBUTING.md#format-your-commit-messages-with-readability-in-mind>`_
   page in the main Blazium repository.
 
 4. GitHub checklist
@@ -365,7 +365,7 @@ out more broadly to ask for help reviewing. Consider asking:
   backported to other branches. Be wary of people making PRs on the version they
   are using (e.g, ``3.3``) and guide them to make a change against a
   higher-order branch (e.g. ``3.x``). If the change is not applicable for the
-  ``master`` branch, the initial PR can be made against the current maintenance
+  ``blazium-dev`` branch, the initial PR can be made against the current maintenance
   branch, such as ``3.x``. It's okay for people to make multiple PRs for each
   target branch, especially if the changes cannot be easily backported.
   Cherry-picking is also an option, if possible. Use the appropriate labels if
@@ -398,7 +398,7 @@ out more broadly to ask for help reviewing. Consider asking:
 
   These link the PR and the referenced issue together and allow GitHub to
   auto-close the latter when you merge the changes. Note, that this only works
-  for the PRs that target the ``master`` branch. For others you need to pay
+  for the PRs that target the ``blazium-dev`` branch. For others you need to pay
   attention and close the related issues manually. Do it with *"Fixed by #..."*
   or *"Resolved by #..."* comment to clearly indicate the act for future
   contributors.
@@ -406,7 +406,7 @@ out more broadly to ask for help reviewing. Consider asking:
 * **For the issues that get closed by the PR add the closest
   relevant milestone.**
 
-  In other words, if the PR is targeting the ``master`` branch, but is then also
+  In other words, if the PR is targeting the ``blazium-dev`` branch, but is then also
   cherrypicked for ``3.x``, the next ``3.x`` release would be the appropriate
   milestone for the closed issue.
 

--- a/contributing/workflow/pr_workflow.rst
+++ b/contributing/workflow/pr_workflow.rst
@@ -7,7 +7,7 @@ Pull request workflow
 
 The so-called "PR workflow" used by Blazium is common to many projects using
 Git, and should be familiar to veteran free software contributors. The idea
-is that only a small number (if any) commit directly to the *master* branch.
+is that only a small number (if any) commit directly to the *blazium-dev* branch.
 Instead, contributors *fork* the project (i.e. create a copy of it, which
 they can modify as they wish), and then use the GitHub interface to request
 a *pull* from one of their fork's branches to one branch of the original
@@ -17,7 +17,7 @@ The resulting *pull request* (PR) can then be reviewed by other contributors,
 which might approve it, reject it, or most often request that modifications
 be done. Once approved, the PR can then be merged by one of the core
 developers, and its commit(s) will become part of the target branch (usually
-the *master* branch).
+the *blazium-dev* branch).
 
 We will go together through an example to show the typical workflow and
 associated Git commands. But first, let's have a quick look at the
@@ -51,22 +51,22 @@ which quickly leads to PRs with an unreadable Git history (especially after peer
 
 The branches on the Git repository are organized as follows:
 
--  The ``master`` branch is where the development of the next major version
+-  The ``blazium-dev`` branch is where the development of the next major version
    occurs. As a development branch, it can be unstable
    and is not meant for use in production. This is where PRs should be done
    in priority.
 -  The stable branches are named after their version, e.g. ``3.1`` and ``2.1``.
-   They are used to backport bugfixes and enhancements from the ``master``
+   They are used to backport bugfixes and enhancements from the ``blazium-dev``
    branch to the currently maintained stable release (e.g. 3.1.2 or 2.1.6).
    As a rule of thumb, the last stable branch is maintained until the next
    minor version (e.g. the ``3.0`` branch was maintained until the release of
    Godot 3.1).
    If you want to make PRs against a maintained stable branch, please check
-   first if your changes are also relevant for the ``master`` branch, and if so
-   make the PR for the ``master`` branch in priority. Release managers can then
+   first if your changes are also relevant for the ``blazium-dev`` branch, and if so
+   make the PR for the ``blazium-dev`` branch in priority. Release managers can then
    cherry-pick the fix to a stable branch if relevant.
 -  There might occasionally be feature branches, usually meant to be merged into
-   the ``master`` branch at some time.
+   the ``blazium-dev`` branch at some time.
 
 Forking and cloning
 -------------------
@@ -114,7 +114,7 @@ We will start by setting up a reference to the original repository that we forke
 
 This will create a reference named ``upstream`` pointing to the original
 ``blazium-engine/blazium`` repository. This will be useful when you want to pull new
-commits from its ``master`` branch to update your fork. You have another
+commits from its ``blazium-dev`` branch to update your fork. You have another
 remote reference named ``origin``, which points to your fork (``USERNAME/blazium``).
 
 You only need to do the above steps once, as long as you keep that local
@@ -139,13 +139,13 @@ file.
 Branching
 ---------
 
-By default, the ``git clone`` should have put you on the ``master`` branch of
+By default, the ``git clone`` should have put you on the ``blazium-dev`` branch of
 your fork (``origin``). To start your own feature development, we will create
 a feature branch:
 
 ::
 
-    # Create the branch based on the current branch (master)
+    # Create the branch based on the current branch (blazium-dev)
     git branch better-project-manager
 
     # Change the current branch to the new one
@@ -158,11 +158,11 @@ This command is equivalent:
     # Change the current branch to a new named one, based on the current branch
     git checkout -b better-project-manager
 
-If you want to go back to the ``master`` branch, you'd use:
+If you want to go back to the ``blazium-dev`` branch, you'd use:
 
 ::
 
-    git checkout master
+    git checkout blazium-dev
 
 You can see which branch you are currently on with the ``git branch``
 command:
@@ -172,37 +172,37 @@ command:
     git branch
       2.1
     * better-project-manager
-      master
+      blazium-dev
 
-Be sure to always go back to the ``master`` branch before creating a new branch,
+Be sure to always go back to the ``blazium-dev`` branch before creating a new branch,
 as your current branch will be used as the base for the new one. Alternatively,
 you can specify a custom base branch after the new branch's name:
 
 ::
 
-    git checkout -b my-new-feature master
+    git checkout -b my-new-feature blazium-dev
 
 Updating your branch
 --------------------
 
 This would not be needed the first time (just after you forked the upstream
 repository). However, the next time you want to work on something, you will
-notice that your fork's ``master`` is several commits behind the upstream
-``master`` branch: pull requests from other contributors would have been merged
+notice that your fork's ``blazium-dev`` is several commits behind the upstream
+``blazium-dev`` branch: pull requests from other contributors would have been merged
 in the meantime.
 
 To ensure there won't be conflicts between the feature you develop and the
-current upstream ``master`` branch, you will have to update your branch by
+current upstream ``blazium-dev`` branch, you will have to update your branch by
 *pulling* the upstream branch.
 
 ::
 
-    git pull --rebase upstream master
+    git pull --rebase upstream blazium-dev
 
 The ``--rebase`` argument will ensure that any local changes that you committed
 will be re-applied *on top* of the pulled branch, which is usually what we want
 in our PR workflow. This way, when you open a pull request, your own commits will
-be the only difference with the upstream ``master`` branch.
+be the only difference with the upstream ``blazium-dev`` branch.
 
 While rebasing, conflicts may arise if your commits modified code that has been
 changed in the upstream branch in the meantime. If that happens, Git will stop at
@@ -238,7 +238,7 @@ section <doc_pr_workflow_rebase>` for instructions.
 
 .. tip:: If at any time you want to *reset* a local branch to a given commit or branch,
          you can do so with ``git reset --hard <commit ID>`` or
-         ``git reset --hard <remote>/<branch>`` (e.g. ``git reset --hard upstream/master``).
+         ``git reset --hard <remote>/<branch>`` (e.g. ``git reset --hard upstream/blazium-dev``).
 
          Be warned that this will remove any changes that you might have committed in
          this branch. If you ever lose commits by mistake, use the ``git reflog`` command
@@ -321,7 +321,7 @@ Here's how the shell history could look like on our example:
     git log
 
 With this, we should have two new commits in our ``better-project-manager``
-branch which were not in the ``master`` branch. They are still only local
+branch which were not in the ``blazium-dev`` branch. They are still only local
 though, the remote fork does not know about them, nor does the upstream repo.
 
 Pushing changes to a remote
@@ -359,9 +359,9 @@ Issuing a pull request
 ----------------------
 
 When you load your fork's branch on GitHub, you should see a line saying
-*"This branch is 2 commits ahead of blazium-engine:master."* (and potentially some
-commits behind, if your ``master`` branch was out of sync with the upstream
-``master`` branch).
+*"This branch is 2 commits ahead of blazium-engine:blazium-dev."* (and potentially some
+commits behind, if your ``blazium-dev`` branch was out of sync with the upstream
+``blazium-dev`` branch).
 
 .. image:: img/github_fork_make_pr.png
 
@@ -453,25 +453,25 @@ the so-called ``HEAD``.
 
 While you can give any commit ID to ``git rebase -i`` and review everything in
 between, the most common and convenient workflow involves rebasing on the
-upstream ``master`` branch, which you can do with:
+upstream ``blazium-dev`` branch, which you can do with:
 
 ::
 
-    git rebase -i upstream/master
+    git rebase -i upstream/blazium-dev
 
 .. note:: Referencing branches in Git is a bit tricky due to the distinction
-          between remote and local branches. Here, ``upstream/master`` (with a
+          between remote and local branches. Here, ``upstream/blazium-dev`` (with a
           `/`) is a local branch which has been pulled from the ``upstream``
-          remote's ``master`` branch.
+          remote's ``blazium-dev`` branch.
 
           Interactive rebases can only be done on local branches, so the `/`
           is important here. As the upstream remote changes frequently, your
-          local ``upstream/master`` branch may become outdated, so you can
-          update it with ``git fetch upstream master``. Contrarily to
-          ``git pull --rebase upstream master`` which would update your
+          local ``upstream/blazium-dev`` branch may become outdated, so you can
+          update it with ``git fetch upstream blazium-dev``. Contrarily to
+          ``git pull --rebase upstream blazium-dev`` which would update your
           currently checked out branch, ``fetch`` will only update the
-          ``upstream/master`` reference (which is distinct from your local
-          ``master`` branch... yes it's confusing, but you'll become familiar
+          ``upstream/blazium-dev`` reference (which is distinct from your local
+          ``blazium-dev`` branch... yes it's confusing, but you'll become familiar
           with this little by little).
 
 This will open a text editor (``vi`` by default, see
@@ -532,18 +532,18 @@ Rebasing onto another branch
 
 If you have accidentally opened your PR on the wrong branch, or need to target another branch
 for some reason, you might need to filter out a lot of commits that differ between the old branch
-(for example ``4.2``) and the new branch (for example ``master``). This can make rebasing difficult
+(for example ``4.2``) and the new branch (for example ``blazium-dev``). This can make rebasing difficult
 and tedious. Fortunately ``git`` has a command just for this situation, ``git rebase --onto``.
 
-If your PR was created from the ``4.2`` branch and you want to update it to instead start at ``master``
+If your PR was created from the ``4.2`` branch and you want to update it to instead start at ``blazium-dev``
 the following steps *should* fix this in one step:
 
 .. code-block:: text
 
-    git rebase -i --onto master 4.2
+    git rebase -i --onto blazium-dev 4.2
 
-This will take all the commits on your branch *after* the ``4.2`` branch, and then splice them on top of ``master``,
-ignoring any commits from the ``4.2`` branch not on the ``master`` branch. You may still need to do some fixing, but
+This will take all the commits on your branch *after* the ``4.2`` branch, and then splice them on top of ``blazium-dev``,
+ignoring any commits from the ``4.2`` branch not on the ``blazium-dev`` branch. You may still need to do some fixing, but
 this command should save you a lot of tedious work removing commits.
 
 Just like above for the interactive rebase you need to force push your branch to handle the different changes:

--- a/tutorials/export/changing_application_icon_for_windows.rst
+++ b/tutorials/export/changing_application_icon_for_windows.rst
@@ -132,7 +132,7 @@ the **Application > Icon** field.
     If rcedit fails to change the icon, you can instead
     :ref:`compile your own Windows export templates <doc_compiling_for_windows>`
     with the icon changed. To do so, replace
-    `platform/windows/godot.ico <https://github.com/godotengine/godot/blob/master/platform/windows/godot.ico>`__
+    `platform/windows/icons/blazium_release.ico <https://github.com/blazium-engine/blazium/blob/blazium-dev/platform/windows/icons/blazium_release.ico>`__
     with your own ICO file *before* compiling export templates.
 
     Once this is done, you can specify your export templates as custom export

--- a/tutorials/export/exporting_for_web.rst
+++ b/tutorials/export/exporting_for_web.rst
@@ -402,7 +402,7 @@ supported on your web server for further file size savings.
 .. tip::
 
     The Godot repository includes a
-    `Python script to host a local web server <https://raw.githubusercontent.com/godotengine/godot/master/platform/web/serve.py>`__.
+    `Python script to host a local web server <https://raw.githubusercontent.com/blazium-engine/blazium/blazium-dev/platform/web/serve.py>`__.
     This script is intended for testing the web editor, but it can also be used to test exported projects.
 
     Save the linked script to a file called ``serve.py``, move this file to the

--- a/tutorials/i18n/localization_using_gettext.rst
+++ b/tutorials/i18n/localization_using_gettext.rst
@@ -235,7 +235,7 @@ never compiled in the MO file in the first place.
 Extracting localizable strings from GDScript files
 --------------------------------------------------
 
-The built-in `editor plugin <https://github.com/godotengine/godot/blob/master/modules/gdscript/editor/gdscript_translation_parser_plugin.h>`_
+The built-in `editor plugin <https://github.com/blazium-engine/blazium/blob/blazium-dev/modules/gdscript/editor/gdscript_translation_parser_plugin.h>`_
 recognizes a variety of patterns in source code to extract localizable strings
 from GDScript files, including but not limited to the following:
 

--- a/tutorials/inputs/controllers_gamepads_joysticks.rst
+++ b/tutorials/inputs/controllers_gamepads_joysticks.rst
@@ -11,7 +11,7 @@ Note that more specialized devices such as steering wheels, rudder pedals and
 always work as expected. Overriding force feedback for those devices is also not
 implemented yet. If you have access to one of those devices, don't hesitate to
 `report bugs on GitHub
-<https://github.com/godotengine/godot/blob/master/CONTRIBUTING.md#reporting-bugs>`__.
+<https://github.com/blazium-engine/blazium/blob/blazium-dev/CONTRIBUTING.md#reporting-bugs>`__.
 
 In this guide, you will learn:
 

--- a/tutorials/networking/ssl_certificates.rst
+++ b/tutorials/networking/ssl_certificates.rst
@@ -16,7 +16,7 @@ this same wrapper.
 
 Blazium will try to use the TLS certificate bundle provided by the operating system,
 but also includes the
-`TLS certificate bundle from Mozilla <https://github.com/godotengine/godot/blob/master/thirdparty/certs/ca-certificates.crt>`__
+`TLS certificate bundle from Mozilla <https://github.com/blazium-engine/blazium/blob/blazium-dev/thirdparty/certs/ca-certificates.crt>`__
 as a fallback.
 
 You can alternatively force your own certificate bundle in the Project Settings:

--- a/tutorials/platform/android/android_library.rst
+++ b/tutorials/platform/android/android_library.rst
@@ -113,8 +113,8 @@ Below we break-down the steps used to create the GLTF Viewer app.
 
 - Create / update the application's Activity that will be hosting the Blazium Engine instance. For the sample app, this is `MainActivity <https://github.com/m4gr3d/Godot-Android-Samples/blob/master/apps/gltf_viewer/src/main/java/fhuyakou/godot/app/android/gltfviewer/MainActivity.kt>`_
 
-  - The host Activity should implement the `GodotHost interface <https://github.com/godotengine/godot/blob/master/platform/android/java/lib/src/org/godotengine/godot/GodotHost.java>`_
-  - The sample app uses `Fragments <https://developer.android.com/guide/fragments>`_ to organize its UI, so it uses `GodotFragment <https://github.com/godotengine/godot/blob/master/platform/android/java/lib/src/org/godotengine/godot/GodotFragment.java>`_, a fragment component provided by the Blazium Android library to automatically host and manage the Blazium Engine instance.
+  - The host Activity should implement the `GodotHost interface <https://github.com/blazium-engine/blazium/blob/blazium-dev/platform/android/java/lib/src/org/godotengine/godot/GodotHost.java>`_
+  - The sample app uses `Fragments <https://developer.android.com/guide/fragments>`_ to organize its UI, so it uses `GodotFragment <https://github.com/blazium-engine/blazium/blob/blazium-dev/platform/android/java/lib/src/org/godotengine/godot/GodotFragment.java>`_, a fragment component provided by the Blazium Android library to automatically host and manage the Blazium Engine instance.
 
   .. code-block:: kotlin
 
@@ -139,9 +139,9 @@ Below we break-down the steps used to create the GLTF Viewer app.
 
 .. note::
 
-  The Godot Android library also provide `GodotActivity <https://github.com/godotengine/godot/blob/master/platform/android/java/lib/src/org/godotengine/godot/GodotActivity.kt>`_, an Activity component that can be extended to automatically host and manage the Godot Engine instance.
+  The Godot Android library also provide `GodotActivity <https://github.com/blazium-engine/blazium/blob/blazium-dev/platform/android/java/lib/src/org/godotengine/godot/GodotActivity.kt>`_, an Activity component that can be extended to automatically host and manage the Godot Engine instance.
 
-  Alternatively, applications can directly create a `Godot <https://github.com/godotengine/godot/blob/master/platform/android/java/lib/src/org/godotengine/godot/Godot.kt>`_ instance, host and manage it themselves.
+  Alternatively, applications can directly create a `Godot <https://github.com/blazium-engine/blazium/blob/blazium-dev/platform/android/java/lib/src/org/godotengine/godot/Godot.kt>`_ instance, host and manage it themselves.
 
 - Using `GodotHost#getHostPlugins(...) <https://github.com/m4gr3d/Godot-Android-Samples/blob/0e3440f357f8be5b4c63a4fe75766793199a99d0/apps/gltf_viewer/src/main/java/fhuyakou/godot/app/android/gltfviewer/MainActivity.kt#L55>`_, the sample app creates a `runtime GodotPlugin instance <https://github.com/m4gr3d/Godot-Android-Samples/blob/master/apps/gltf_viewer/src/main/java/fhuyakou/godot/app/android/gltfviewer/AppPlugin.kt>`_ that's used to send :ref:`signals <doc_signals>` to the ``gdscript`` logic
 

--- a/tutorials/platform/web/customizing_html5_shell.rst
+++ b/tutorials/platform/web/customizing_html5_shell.rst
@@ -21,7 +21,7 @@ Some use-cases where customizing the default page is useful include:
 - Passing custom command line arguments, e.g. ``-s`` to start a ``MainLoop`` script.
 
 The default HTML page is available in the Blazium Engine repository at
-`/misc/dist/html/full-size.html <https://github.com/blazium-engine/blazium/blob/master/misc/dist/html/full-size.html>`__
+`/misc/dist/html/full-size.html <https://github.com/blazium-engine/blazium/blob/blazium-dev/misc/dist/html/full-size.html>`__
 but the following template can be used as a much simpler example:
 
 .. code-block:: html

--- a/tutorials/scripting/gdextension/gdextension_docs_system.rst
+++ b/tutorials/scripting/gdextension/gdextension_docs_system.rst
@@ -181,11 +181,11 @@ The most important step is to build reStructuredText (``.rst``) files from your 
 .. code-block:: bash
 
     # You need a version.py file, so download it first.
-    curl -sSLO https://raw.githubusercontent.com/godotengine/godot/refs/heads/master/version.py
+    curl -sSLO https://raw.githubusercontent.com/blazium-engine/blazium/refs/heads/blazium-dev/version.py
 
     # Edit version.py according to your project before proceeding.
     # Then, run the rst generator. You'll need to have Python installed for this command to work.
-    curl -sSL https://raw.githubusercontent.com/godotengine/godot/master/doc/tools/make_rst.py | python3 - -o "docs/classes" -l "en" doc_classes
+    curl -sSL https://raw.githubusercontent.com/blazium-engine/blazium/blazium-dev/doc/tools/make_rst.py | python3 - -o "docs/classes" -l "en" doc_classes
 
 Your ``.rst`` files will now be available in ``docs/classes/``. From here, you can use
 any documentation builder that supports reStructuredText syntax to create a website from them.

--- a/tutorials/scripting/gdscript/gdscript_basics.rst
+++ b/tutorials/scripting/gdscript/gdscript_basics.rst
@@ -140,7 +140,7 @@ keywords are reserved words (tokens), they can't be used as identifiers.
 Operators (like ``in``, ``not``, ``and`` or ``or``) and names of built-in types
 as listed in the following sections are also reserved.
 
-Keywords are defined in the `GDScript tokenizer <https://github.com/blazium-engine/blazium/blob/master/modules/gdscript/gdscript_tokenizer.cpp>`_
+Keywords are defined in the `GDScript tokenizer <https://github.com/blazium-engine/blazium/blob/blazium-dev/modules/gdscript/gdscript_tokenizer.cpp>`_
 in case you want to take a look under the hood.
 
 +------------+---------------------------------------------------------------------------------------------------------------------------------------------------+

--- a/tutorials/shaders/shader_reference/shader_functions.rst
+++ b/tutorials/shaders/shader_reference/shader_functions.rst
@@ -72,7 +72,7 @@ originally published by Khronos Group under the
 `Open Publication License <https://opencontent.org/openpub>`__.
 Each function description links to the corresponding official OpenGL
 documentation. Modification history for this page can be found on
-`GitHub <https://github.com/godotengine/godot-docs/blob/master/tutorials/shaders/shader_reference/shader_functions.rst>`__.
+`GitHub <https://github.com/blazium-engine/blazium-docs/blob/blazium-dev/tutorials/shaders/shader_reference/shader_functions.rst>`__.
 
 .. rst-class:: classref-section-separator
 

--- a/tutorials/shaders/shaders_style_guide.rst
+++ b/tutorials/shaders/shaders_style_guide.rst
@@ -11,7 +11,7 @@ auto-formatting tools.
 Since the Blazium shader language is close to C-style languages and GLSL, this
 guide is inspired by Blazium's own GLSL formatting. You can view examples of
 GLSL files in Blazium's source code
-`here <https://github.com/blazium-engine/blazium/blob/master/drivers/gles3/shaders/>`__.
+`here <https://github.com/blazium-engine/blazium/tree/blazium-dev/drivers/gles3/shaders>`__.
 
 Style guides aren't meant as hard rulebooks. At times, you may not be able to
 apply some of the guidelines below. When that happens, use your best judgment,

--- a/tutorials/ui/bbcode_in_richtextlabel.rst
+++ b/tutorials/ui/bbcode_in_richtextlabel.rst
@@ -826,7 +826,7 @@ See this image for a list of color constants:
 
 .. image:: /img/color_constants.png
 
-`View at full size <https://raw.githubusercontent.com/godotengine/godot-docs/master/img/color_constants.png>`__
+`View at full size <https://raw.githubusercontent.com/blazium-engine/blazium-docs/blazium-dev/img/color_constants.png>`__
 
 .. _doc_bbcode_in_richtextlabel_hex_colors:
 


### PR DESCRIPTION
Closes #29 

Fixes almost all references to `master` branch instead of `blazium-dev` and `godotengine/godot:master` branch to `blazium-engine/blazium:blazium-dev`.

Some notable exceptions:
- `tutorials/inputs/controllers_gamepads_joysticks.rst` -- Did not change this to Blazium, because these kind of contributions should be made upstream
- `tutorials/migrating/upgrading_to_godot_4.rst` -- Probably needs to be rewritten for Blazium
- `tutorials/scripting/gdextension/gdextension_cpp_example.rst` -- Not sure what the situation with blazium-cpp is so I didn't touch this one

Also didn't bother with any changes to any files under `classes` as those should be changed in the main `blazium` repo.
